### PR TITLE
Add go implementations

### DIFF
--- a/go-fibo/README.md
+++ b/go-fibo/README.md
@@ -1,0 +1,28 @@
+Go fibonacci implementations:
+ - Recursive standard implementation
+ - Fast implementation with loop
+ - Implementation using `struct`s and `interface`s
+
+Known issues: `struct`s implementation has interfaces as struct fields,
+this mean its fields memory will be allocated in heap instead of stack,
+so it has GC overhead; other implementations can compute fibonacci number
+in stack.
+
+## How to build
+
+ - Recursive: `go build ./cmd/recursive`
+ - Fast: `go build ./cmd/fast`
+ - Structs: `go build ./cmd/structs`
+
+Then you can run it with:
+ - `./recursive <n> <cnt>`
+ - `./fast <n> <cnt>`
+ - `./structs <n> <cnt>`
+
+## Test
+
+To run tests use `go test`
+
+## Benchmarks
+
+To run benchmarks use: `go test -bench=.`

--- a/go-fibo/cmd/fast/main.go
+++ b/go-fibo/cmd/fast/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/yegor256/fibonacci/go-fibo"
+)
+
+func main() {
+	inp, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	cycles, err := strconv.Atoi(os.Args[2])
+	if err != nil {
+		panic(err)
+	}
+	var sum int32
+	for i := 0; i < cycles; i++ {
+		sum += fibo.Fast(int32(inp))
+	}
+	fmt.Printf("fibo(%d)*%d = %d\n", inp, cycles, sum)
+}

--- a/go-fibo/cmd/recursive/main.go
+++ b/go-fibo/cmd/recursive/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/yegor256/fibonacci/go-fibo"
+)
+
+func main() {
+	inp, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	cycles, err := strconv.Atoi(os.Args[2])
+	if err != nil {
+		panic(err)
+	}
+	var sum int32
+	for i := 0; i < cycles; i++ {
+		sum += fibo.Calculate(int32(inp))
+	}
+	fmt.Printf("fibo(%d)*%d = %d\n", inp, cycles, sum)
+}

--- a/go-fibo/cmd/structs/main.go
+++ b/go-fibo/cmd/structs/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/yegor256/fibonacci/go-fibo"
+)
+
+func main() {
+	inp, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		panic(err)
+	}
+	cycles, err := strconv.Atoi(os.Args[2])
+	if err != nil {
+		panic(err)
+	}
+	var sum int32
+	for i := 0; i < cycles; i++ {
+		sum += fibo.New(int32(inp)).Value()
+	}
+	fmt.Printf("fibo(%d)*%d = %d\n", inp, cycles, sum)
+}

--- a/go-fibo/fibo.go
+++ b/go-fibo/fibo.go
@@ -1,0 +1,83 @@
+package fibo
+
+type int32number int32
+
+func (n int32number) intVal() int32 {
+	return int32(n)
+}
+
+type number interface {
+	intVal() int32
+}
+
+type boolean interface {
+	boolVal() bool
+}
+
+type less struct {
+	left, right number
+}
+
+func (l less) boolVal() bool {
+	return l.left.intVal() < l.right.intVal()
+}
+
+type sub struct {
+	left, right number
+}
+
+func (s sub) intVal() int32 {
+	return s.left.intVal() - s.right.intVal()
+}
+
+type add struct {
+	left, right number
+}
+
+func (a add) intVal() int32 {
+	return a.left.intVal() + a.right.intVal()
+}
+
+type condition struct {
+	pred boolean
+	yes, no number
+}
+
+func (c condition) intVal() int32 {
+	if c.pred.boolVal() {
+		return c.yes.intVal()
+	}
+	return c.no.intVal()
+}
+
+
+func (f Fibo) intVal() int32 {
+	const (
+		one = int32number(1)
+		two = int32number(2)
+	)
+	cnd := condition{
+		pred: less{f.n, two},
+		yes: one,
+		no: add{
+			Fibo{sub{f.n, one}},
+			Fibo{sub{f.n, two}},
+		},
+	}
+	return cnd.intVal()
+}
+
+// Fibo nacci
+type Fibo struct {
+	n number
+}
+
+// Value of fibonacci
+func (f Fibo) Value() int32 {
+	return f.intVal()
+}
+
+// New fibonacci number
+func New(inp int32) Fibo {
+	return Fibo{int32number(inp)}
+}

--- a/go-fibo/fibo_test.go
+++ b/go-fibo/fibo_test.go
@@ -1,0 +1,52 @@
+package fibo
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFiboStructs(t *testing.T) {
+	testFibo(t, func(x int32) int32 {
+		return New(x).Value()
+	})
+}
+
+func TestFiboFast(t *testing.T) {
+	testFibo(t, func(x int32) int32 {
+		return Fast(x)
+	})
+}
+
+func testFibo(t *testing.T, f func(int32)int32) {
+	var i int32
+	for i = 0; i < 20; i++ {
+		if res, expect := f(i), Calculate(i); res != expect {
+			t.Errorf("fibo(%d) expect %d but was %d", i, expect, res)
+		}
+	}
+}
+
+func BenchmarkRecursive(b *testing.B) {
+	bench(b, Calculate)
+}
+
+func BenchmarkStructs(b *testing.B) {
+	bench(b, func(n int32) int32 {
+		return New(n).Value()
+	})
+}
+
+func BenchmarkFast(b *testing.B) {
+	bench(b, func(n int32) int32 {
+		return Fast(n)
+	})
+}
+
+func bench(b *testing.B, f func(int32) int32) {
+	var i int32
+	for i = 0; i < 20; i++ {
+		b.Run(fmt.Sprintf("bench-%d", i), func(b *testing.B) {
+			f(i)
+		})
+	}
+}

--- a/go-fibo/go.mod
+++ b/go-fibo/go.mod
@@ -1,0 +1,3 @@
+module github.com/yegor256/fibonacci/go-fibo
+
+go 1.17

--- a/go-fibo/loop.go
+++ b/go-fibo/loop.go
@@ -1,0 +1,14 @@
+package fibo
+
+// Fast fibonacci calculation
+func Fast(n int32) int32 {
+	if n <= 1 {
+		return 1
+	}
+	var x, p, pp int32
+	pp, p = 0, 1
+	for x = 2; x <= n; x++ {
+		pp, p = p, p + pp
+	}
+	return p + pp
+}

--- a/go-fibo/recursive.go
+++ b/go-fibo/recursive.go
@@ -1,0 +1,9 @@
+package fibo
+
+// Calculate fibonacci for input
+func Calculate(inp int32) int32 {
+	if inp <= 1 {
+		return 1
+	}
+	return Calculate(inp - 1) + Calculate(inp - 2)
+}


### PR DESCRIPTION
Add 3 Go Fibonacci implementations:
 - Recursive standard implementation
 - Fast implementation with loop
 - Implementation using `struct`s and `interface`s

Check `./go/README.md` for details.

I'm not sure how to include this into current `Makefile`, because it doesn't have any documentation.