### PR TITLE
Add low-latency Java Fibonacci implementation

### DIFF
--- a/java/LowLatency.java
+++ b/java/LowLatency.java
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
+final class LowLatency {
+    private LowLatency() {
+        // Utility class.
+    }
+
+    public static long fibo(final int x) {
+        final int n = x + 1;
+        long a = 1L;
+        long b = 1L;
+        int bit;
+        if (n >= 64) {
+            bit = 32;
+        } else if (n >= 32) {
+            bit = 16;
+        } else if (n >= 16) {
+            bit = 8;
+        } else if (n >= 8) {
+            bit = 4;
+        } else if (n >= 4) {
+            bit = 2;
+        } else if (n >= 2) {
+            bit = 1;
+        } else {
+            bit = 0;
+        }
+        while (bit != 0) {
+            final long d = a * ((b << 1) - a);
+            final long e = (a * a) + (b * b);
+            if ((n & bit) == 0) {
+                a = d;
+                b = e;
+            } else {
+                a = e;
+                b = d + e;
+            }
+            bit >>>= 1;
+        }
+        return a;
+    }
+
+    public static void main(final String... args) {
+        if (args.length != 2) {
+            System.out.print("Two args required: INPUT and CYCLES\n");
+            return;
+        }
+        final int input = java.lang.Integer.parseInt(args[0]);
+        final int cycles = java.lang.Integer.parseInt(args[1]);
+        long total = 0L;
+        long f = 0L;
+        for (int i = 0; i < cycles; ++i) {
+            f = fibo(input);
+            total += f;
+        }
+        System.out.print(
+                String.format(
+                        "%d-th Fibonacci number is %d\nTotal is %d\n",
+                        input, f, total
+                )
+        );
+    }
+}


### PR DESCRIPTION
This PR adds one more Java implementation style focused on low latency.

The main motivation is to make the comparison space in this repository a bit richer, not only between Java styles, but also between implementation philosophies across different languages.

At the moment, Java already contains recursive, functional, object-oriented, and record-based variants. This change adds a version that is intentionally optimized for latency:
- primitive arithmetic only
- no recursion
- no object allocation in the hot path
- no virtual dispatch
- JIT-friendly control flow
- `long`-based computation instead of `int`

So this is meant to represent a different performance-oriented style that can be compared both:
- against the existing Java implementations
- and against low-level / performance-oriented approaches in other languages in this repository

### Implementation notes

The new `java/LowLatency.java` implementation uses an iterative fast-doubling approach specialized for the practical `long` range.

It keeps all state in primitive local variables and avoids heap pressure during computation.

### Local benchmark notes

I mostly measured it as an in-process benchmark in order to reduce JVM startup noise.

Environment:
- Ubuntu 24.04.3 LTS under WSL2
- kernel: `6.6.87.2-microsoft-standard-WSL2`
- HotSpot: `OpenJDK 64-Bit Server VM 25.0.2+10-Ubuntu-124.04`
- JVM flags:
  - `-Xbatch`
  - `-XX:-TieredCompilation`
  - `-Xms256m`
  - `-Xmx256m`

### Observations

For local in-process measurements on HotSpot, this implementation was much faster than the existing Java recursive/functional variants on the tested inputs.

Representative local numbers:
- `input=32`
  - `LowLatency`: about `4.48 ns/op`
  - `Recursion`: about `6898173 ns/op`
  - `Functions`: about `6772006 ns/op`
- `input=91`
  - `LowLatency`: about `4.41 ns/op`

I also inspected the HotSpot C2 output for `LowLatency::fibo`:
- C2 compiled
- Java bytecode size: `149 bytes`
- generated main machine code size: `192 bytes`

This suggests that the hot path is already reduced mostly to arithmetic and control flow, with little JVM overhead left inside the compiled method.

### GC / runtime noise

In the HotSpot run used for inspection:
- no GC events occurred during the measured benchmark
- heap usage stayed very small
- the method did not appear to be GC-bound or allocation-bound

### CPU cycles

I also wanted to include CPU-cycle measurements, since that is indeed an important metric.

However, on this machine I was running under WSL2 with the `6.6.87.2-microsoft-standard-WSL2` kernel, and I was not able to get a matching `perf` setup for reliable per-kernel cycle counting. Because of that, I am not including cycle numbers in this PR in order to avoid presenting potentially misleading data.

### Extra material

I attached the full HotSpot C2 machine-code dump for `LowLatency::fibo` separately as a text file.
[LowLatency-hotspot-c2-assembly.txt](https://github.com/user-attachments/files/27028246/LowLatency-hotspot-c2-assembly.txt)