### PR TITLE
Fix fibonacci base case across all implementations (#76)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ RUSTS = $(wildcard rust/*.rs)
 PASCALS = $(wildcard pascal/*.pp)
 # LISPS = $(wildcard lisp/*.lisp)
 HASKELLS = $(wildcard haskell/*.hs)
-JAVAS = $(wildcard java/*.java)
+JAVAS = $(filter-out java/FiboTest.java,$(wildcard java/*.java))
 CSHARPS = $(subst /Program.cs,.cs,$(wildcard csharp/*/Program.cs))
 # Eiffel doesn't work, this may help: https://github.com/eiffel-docker/eiffel/issues/3
 # EIFFELS = eiffel/application.e
@@ -155,6 +155,11 @@ install: Makefile
 		sudo mkdir -p /usr/local/opt
 		sudo wget --no-verbose https://repo.maven.apache.org/maven2/net/sf/saxon/Saxon-HE/9.8.0-5/Saxon-HE-9.8.0-5.jar -O /usr/local/opt/Saxon.jar
 	fi
+
+test: Makefile
+	mkdir -p tmp/test
+	$(JAVAC) -d tmp/test java/*.java
+	cd tmp/test && java FiboTest
 
 env: Makefile
 	$(CC) --version

--- a/ada/recursion.adb
+++ b/ada/recursion.adb
@@ -15,7 +15,7 @@ procedure Recursion is
   function Fib(P: Integer) return Integer is
   begin
     if P < 2 then
-      return 1;
+      return P;
     else
       return Fib(P-1) + Fib(P-2);
     end if;

--- a/cpp/binpow-matrix.cpp
+++ b/cpp/binpow-matrix.cpp
@@ -29,7 +29,6 @@ matrix2on2 binpow(const matrix2on2 &a, int n) {
 }
 // See https://e-maxx.ru/algo/fibonacci_numbers#8
 int calc(int n) {
-  n += 1;
   const matrix2on2 factor = {0, 1, 1, 1};
   const matrix2on2 multiplier = binpow(factor, n);
   const matrix2on2 base = {0, 1, 0, 0};

--- a/cpp/classes.cpp
+++ b/cpp/classes.cpp
@@ -36,7 +36,7 @@ class Fibo {
 public:
   explicit Fibo(int num)
     : res(Less(num, 2).get()
-            ? 1
+            ? num
             : Add(Fibo(Sub(num, 1).get()).get(), Fibo(Sub(num, 2).get()).get())
                 .get()) {}
   int get() const { return res; }

--- a/cpp/decorators.cpp
+++ b/cpp/decorators.cpp
@@ -35,7 +35,7 @@ private:
 
 class First : public Fibo {
 public:
-  int get() override { return 1; }
+  int get() override { return 0; }
   Fibo* next() override { return new Second(this); }
 };
 

--- a/cpp/functions.cpp
+++ b/cpp/functions.cpp
@@ -11,7 +11,7 @@ int __attribute__((noinline)) add(int a, int b) { return a + b; }
 
 int __attribute__((noinline)) fibo(int x) {
   if (less(x, 2)) {
-    return 1;
+    return x;
   }
   return add(fibo(sub(x, 1)), fibo(sub(x, 2)));
 }

--- a/cpp/functions_with_new.cpp
+++ b/cpp/functions_with_new.cpp
@@ -31,7 +31,7 @@ int __attribute__((noinline)) fibo(int x);
 int __attribute__((noinline))
 fibo_impl(int const *const px, int const *const p1, int const *const p2) {
   if (op(less_impl, *px, *p2) != 0) {
-    return *p1;
+    return *px;
   }
   return op(
     add_impl, fibo(op(sub_impl, *px, *p1)), fibo(op(sub_impl, *px, *p2)));

--- a/cpp/inlines.cpp
+++ b/cpp/inlines.cpp
@@ -11,7 +11,7 @@ inline int add(int a, int b) { return a + b; }
 
 int calc(int x) {
   if (less(x, 2)) {
-    return 1;
+    return x;
   }
   return add(calc(sub(x, 1)), calc(sub(x, 2)));
 }

--- a/cpp/interpreter.cpp
+++ b/cpp/interpreter.cpp
@@ -181,6 +181,6 @@ private:
 
 int calc(int x) {
   Interpret<int> result =
-    Interpret<int>(cptr(new Fibo(cptr(new Value<int>(x + 1)))));
+    Interpret<int>(cptr(new Fibo(cptr(new Value<int>(x)))));
   return result.get();
 }

--- a/cpp/lambdas.cpp
+++ b/cpp/lambdas.cpp
@@ -71,7 +71,7 @@ int add(struct lambda* arg) { return call(arg->first) + call(arg->second); }
 
 int fibo(struct lambda* arg) {
   const int x = call(arg->first);
-  return call(make(iff, make(less, integer(x), integer(2), nullptr), integer(1),
+  return call(make(iff, make(less, integer(x), integer(2), nullptr), integer(x),
     make(add,
       make(fibo, make(sub, integer(x), integer(1), nullptr), nullptr, nullptr),
       make(fibo, make(sub, integer(x), integer(2), nullptr), nullptr, nullptr),

--- a/cpp/loop.cpp
+++ b/cpp/loop.cpp
@@ -6,10 +6,10 @@
 int calc(int x) {
   int p1 = 0;
   int p2 = 1;
-  for (int i = 1; i < x; ++i) {
+  for (int i = 0; i < x; ++i) {
     const int t = p2;
     p2 = p1 + p2;
     p1 = t;
   }
-  return p1 + p2;
+  return p1;
 }

--- a/cpp/matrixes.cpp
+++ b/cpp/matrixes.cpp
@@ -48,4 +48,4 @@ int fibonacci(unsigned int n) {
   return ret.at(0).at(1);
 }
 
-int calc(int x) { return fibonacci(x + 1); }
+int calc(int x) { return fibonacci(x); }

--- a/cpp/novirtual.cpp
+++ b/cpp/novirtual.cpp
@@ -65,7 +65,7 @@ public:
   ~Fibo() { delete value; }
   int get() {
     if (Less(*value, 2).get()) {
-      return 1;
+      return *value;
     }
     return Add(
       Fibo(Sub(*value, 1).get()).get(), Fibo(Sub(*value, 2).get()).get())

--- a/cpp/objects.cpp
+++ b/cpp/objects.cpp
@@ -95,7 +95,7 @@ public:
   ~Fibo() override { delete value; }
   int get() override {
     Int* iff =
-      new If(new Less(new Integer(value), new Integer(2)), new Integer(1),
+      new If(new Less(new Integer(value), new Integer(2)), new Integer(value),
         new Add(new Fibo(new Sub(new Integer(value), new Integer(1))),
           new Fibo(new Sub(new Integer(value), new Integer(2)))));
     const int result = iff->get();

--- a/cpp/recursion.cpp
+++ b/cpp/recursion.cpp
@@ -5,7 +5,7 @@
 
 int calc(int x) {
   if (x < 2) {
-    return 1;
+    return x;
   }
   return calc(x - 1) + calc(x - 2);
 }

--- a/cpp/stack_objects.cpp
+++ b/cpp/stack_objects.cpp
@@ -30,7 +30,7 @@ public:
 class Fibo : public Operation {
 public:
   explicit Fibo(int num)
-    : Operation(Less(num, 2).get() != 0 ? 1
+    : Operation(Less(num, 2).get() != 0 ? num
                                         : Add(Fibo(Sub(num, 1).get()).get(),
                                             Fibo(Sub(num, 2).get()).get())
                                             .get()) {}

--- a/cpp/static_member_functions.cpp
+++ b/cpp/static_member_functions.cpp
@@ -27,7 +27,7 @@ class Fibo {
 public:
   static int Solve(int num) {
     if (Comparer::Solve(num, 2)) {
-      return 1;
+      return num;
     }
     return Adder::Solve(Fibo::Solve(Substructor::Solve(num, 1)),
       Fibo::Solve(Substructor::Solve(num, 2)));

--- a/csharp/Functions/Program.cs
+++ b/csharp/Functions/Program.cs
@@ -24,7 +24,7 @@ class Program
     {
         if (Less(v, 2))
         {
-            return 1;
+            return v;
         }
         return Add(Fibo(Sub(v, 1)), Fibo(Sub(v, 2)));
     }

--- a/csharp/Objects/Program.cs
+++ b/csharp/Objects/Program.cs
@@ -117,7 +117,7 @@ class Program
         {
             return new If(
                 new Less(this.value, new Integer(2)),
-                new Integer(1),
+                this.value,
                 new Add(
                     new Fibo(new Sub(this.value, new Integer(1))),
                     new Fibo(new Sub(this.value, new Integer(2)))

--- a/csharp/Recursion/Program.cs
+++ b/csharp/Recursion/Program.cs
@@ -9,7 +9,7 @@ class Program
     {
         if (x < 2)
         {
-            return 1;
+            return x;
         }
         return Fibo(x - 1) + Fibo(x - 2);
     }

--- a/csharp/Structs/Program.cs
+++ b/csharp/Structs/Program.cs
@@ -117,7 +117,7 @@ class Program
         {
             return new If(
                 new Less(this.value, new Integer(2)),
-                new Integer(1),
+                this.value,
                 new Add(
                     new Fibo(new Sub(this.value, new Integer(1))),
                     new Fibo(new Sub(this.value, new Integer(2)))

--- a/eiffel/recursion.e
+++ b/eiffel/recursion.e
@@ -11,14 +11,14 @@ feature
 	    inspect
 	      n
 	    when 0 then
-	      Result := 1
+	      Result := 0
 	    when 1 then
 	      Result := 1
 	    else
 	      Result := fib (n-1) + fib (n-2)
 	    end -- inspect
 	  ensure
-	    n = 0 implies Result = 1
+	    n = 0 implies Result = 0
 	    n = 1 implies Result = 1
 	    n > 1 implies Result = fib (n-1) + fib (n-2)
 	  end

--- a/go/fibo.go
+++ b/go/fibo.go
@@ -61,7 +61,7 @@ func (f Fibo) intVal() int64 {
 	)
 	cnd := condition{
 		pred: less{f.n, two},
-		yes: one,
+		yes: f.n,
 		no: add{
 			Fibo{sub{f.n, one}},
 			Fibo{sub{f.n, two}},

--- a/go/loop.go
+++ b/go/loop.go
@@ -5,13 +5,13 @@ package fibo
 
 // Fast fibonacci calculation
 func Fast(n int64) int64 {
-	if n <= 1 {
-		return 1
+	if n < 2 {
+		return n
 	}
 	var x, p, pp int64
 	pp, p = 0, 1
 	for x = 2; x <= n; x++ {
 		pp, p = p, p + pp
 	}
-	return p + pp
+	return p
 }

--- a/go/recursive.go
+++ b/go/recursive.go
@@ -6,7 +6,7 @@ package fibo
 // Calculate fibonacci for input
 func Calculate(x int64) int64 {
 	if x < 2 {
-		return 1
+		return x
 	}
 	return Calculate(x - 1) + Calculate(x - 2)
 }

--- a/haskell/adt.hs
+++ b/haskell/adt.hs
@@ -8,7 +8,7 @@ import Mainlib.Report (run)
 data Fibo = First | Second | Other Fibo Fibo
 
 get :: Fibo -> Int
-get First       = 1
+get First       = 0
 get Second      = 1
 get (Other a b) = get a + get b
 

--- a/haskell/iterate.hs
+++ b/haskell/iterate.hs
@@ -7,7 +7,7 @@ import Mainlib.Report (run)
 
 
 fibo :: Int -> Int
-fibo n = fst $ iterate step (1, 1) !! n where
+fibo n = fst $ iterate step (0, 1) !! n where
     step (a, b) = (b, a + b)
 
 

--- a/haskell/object_dynamic.hs
+++ b/haskell/object_dynamic.hs
@@ -7,7 +7,7 @@ import Mainlib.Report (run)
 import Mainlib.Objects
 
 fibo :: Object Int -> Object Int
-fibo n = fibo' n (oInt 1) (oInt 1) where
+fibo n = fibo' n (oInt 0) (oInt 1) where
     fibo' m a b =
         oIf (oLt m $ oInt 1)
             a

--- a/haskell/objects.hs
+++ b/haskell/objects.hs
@@ -9,7 +9,7 @@ import Mainlib.Objects
 fibo :: Object Int -> Object Int
 fibo x =
     oIf (oLt x $ oInt 2)
-        (oInt 1)
+        x
         (oAdd (fibo $ oSub x $ oInt 1)
               (fibo $ oSub x $ oInt 2))
 

--- a/haskell/polymorphic_recursion.hs
+++ b/haskell/polymorphic_recursion.hs
@@ -22,7 +22,7 @@ instance Ord a => Ord (Number a) where
 
 fibo :: (Ord a, Num a) => a -> a
 fibo n
-    | n <= fromInteger 1 = fromInteger 1
+    | n <= fromInteger 1 = n
     | otherwise          = fibo (n - fromInteger 1) + fibo (n - fromInteger 2)
 
 main :: IO ()

--- a/haskell/recursion.hs
+++ b/haskell/recursion.hs
@@ -7,7 +7,7 @@ import Mainlib.Report (run)
 
 
 fibo :: Int -> Int
-fibo 0 = 1
+fibo 0 = 0
 fibo 1 = 1
 fibo n = fibo (n - 1) + fibo (n - 2)
 

--- a/haskell/tail_recursion.hs
+++ b/haskell/tail_recursion.hs
@@ -6,7 +6,7 @@ module Main where
 import Mainlib.Report (run)
 
 fibo :: Int -> Int
-fibo = fibo' 1 1 where
+fibo = fibo' 0 1 where
     fibo' a _b 0 = a
     fibo' a  b n = fibo' b (a + b) (n - 1)
 

--- a/haskell/zipwith.hs
+++ b/haskell/zipwith.hs
@@ -5,7 +5,7 @@ module Main where
 import Mainlib.Report (run)
 
 fibs :: [Int]
-fibs = 1:1:zipWith (+) fibs (drop 1 fibs)
+fibs = 0:1:zipWith (+) fibs (drop 1 fibs)
 
 fibo :: Int -> Int
 fibo = (fibs !!)

--- a/java/FiboTest.java
+++ b/java/FiboTest.java
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
+final class FiboTest {
+  private FiboTest() {
+    // Utility class.
+  }
+
+  // The standard Fibonacci sequence: F(0)=0, F(1)=1, F(2)=1, F(3)=2, ...
+  private static final int[] EXPECTED = {
+    0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144,
+  };
+
+  public static void main(final String... args) {
+    int failures = 0;
+    failures += check("Recursion.fibo", x -> Recursion.fibo(x));
+    failures += check("Functions.Fibo", x -> Functions.Fibo(x));
+    failures += check(
+      "Objects.Fibo",
+      x -> new Objects.Fibo(new Objects.Integer(x)).get()
+    );
+    failures += check(
+      "Records.Fibo",
+      x -> new Records.Fibo(new Records.Integer(x)).get()
+    );
+    failures += checkLong("LowLatency.fibo", x -> LowLatency.fibo(x));
+    if (failures > 0) {
+      System.out.printf("FiboTest: %d failure(s)%n", failures);
+      System.exit(1);
+    }
+    System.out.println("FiboTest: all checks passed");
+  }
+
+  private static int check(final String name, final IntFn fn) {
+    int failures = 0;
+    for (int i = 0; i < EXPECTED.length; ++i) {
+      final int actual = fn.apply(i);
+      if (actual != EXPECTED[i]) {
+        System.out.printf(
+          "FAIL: %s(%d) = %d, expected %d%n",
+          name, i, actual, EXPECTED[i]
+        );
+        ++failures;
+      }
+    }
+    return failures;
+  }
+
+  private static int checkLong(final String name, final LongFn fn) {
+    int failures = 0;
+    for (int i = 0; i < EXPECTED.length; ++i) {
+      final long actual = fn.apply(i);
+      if (actual != (long) EXPECTED[i]) {
+        System.out.printf(
+          "FAIL: %s(%d) = %d, expected %d%n",
+          name, i, actual, EXPECTED[i]
+        );
+        ++failures;
+      }
+    }
+    return failures;
+  }
+
+  @FunctionalInterface
+  private interface IntFn {
+    int apply(int x);
+  }
+
+  @FunctionalInterface
+  private interface LongFn {
+    long apply(int x);
+  }
+}

--- a/java/Functions.java
+++ b/java/Functions.java
@@ -13,7 +13,7 @@ class Functions {
   }
   static int Fibo(int v) {
     if (Less(v, 2)) {
-      return 1;
+      return v;
     }
     return Add(Fibo(Sub(v, 1)), Fibo(Sub(v, 2)));
   }

--- a/java/LowLatency.java
+++ b/java/LowLatency.java
@@ -7,7 +7,10 @@ final class LowLatency {
     }
 
     public static long fibo(final int x) {
-        final int n = x + 1;
+        if (x < 2) {
+            return x;
+        }
+        final int n = x;
         long a = 1L;
         long b = 1L;
         int bit;

--- a/java/Objects.java
+++ b/java/Objects.java
@@ -80,7 +80,7 @@ class Objects {
     public int get() {
       return new If(
         new Less(this.value, new Integer(2)),
-        new Integer(1),
+        this.value,
         new Add(
           new Fibo(new Sub(this.value, new Integer(1))),
           new Fibo(new Sub(this.value, new Integer(2)))

--- a/java/Records.java
+++ b/java/Records.java
@@ -46,7 +46,7 @@ class Records {
     public int get() {
       return new If(
         new Less(this.value, new Integer(2)),
-        new Integer(1),
+        this.value,
         new Add(
           new Fibo(new Sub(this.value, new Integer(1))),
           new Fibo(new Sub(this.value, new Integer(2)))

--- a/java/Recursion.java
+++ b/java/Recursion.java
@@ -4,7 +4,7 @@
 class Recursion {
   public static int fibo(int x) {
     if (x < 2) {
-      return 1;
+      return x;
     }
     return fibo(x - 1) + fibo(x - 2);
   }

--- a/lisp/recursion.lisp
+++ b/lisp/recursion.lisp
@@ -4,7 +4,7 @@
 (defun fibo (x)
   (if
     (< x 2)
-    1
+    x
     (+
       (fibo (- x 1))
       (fibo (- x 2)))))

--- a/pascal/Objects.pp
+++ b/pascal/Objects.pp
@@ -151,7 +151,7 @@ type
     begin
         Result := TIf.Create(
             TLess.Create(value, TInteger.Create(2)),
-                TInteger.Create(1),
+                value,
                 TAdd.Create(
                     TFibo.Create(TSub.Create(value, TInteger.Create(1))),
                     TFibo.Create(TSub.Create(value, TInteger.Create(2))

--- a/pascal/recursion.pp
+++ b/pascal/recursion.pp
@@ -10,7 +10,7 @@ Uses sysutils;
 Function Fibo(n : Longint) : Longint;
 begin
   if (n < 2) then
-    Fibo := 1
+    Fibo := n
   else
     Fibo := Fibo(n - 1) + Fibo(n - 2);
 end;

--- a/rust/recursion.rs
+++ b/rust/recursion.rs
@@ -5,7 +5,7 @@ use std::env;
 
 pub fn fibonacci(input: u32) -> u32 {
 	match input {
-		0 => 1,
+		0 => 0,
 		1 => 1,
 		n => fibonacci(n - 2) + fibonacci(n - 1)
 	}

--- a/rust/structs.rs
+++ b/rust/structs.rs
@@ -107,7 +107,7 @@ impl<'a> Int for Fibo<'a> {
 		let sub2 = Sub::new(self.x, &two);
 		let prev2 = Fibo::new(&sub2);
 		let right = Add::new(&prev1, &prev2);
-		let iff = If::new(&less, &one, &right);
+		let iff = If::new(&less, self.x, &right);
 		return iff.get();
 	}
 }


### PR DESCRIPTION
@yegor256 — fixes #76. Ready for your review.

## What was wrong

Every recursive implementation hard-coded `return 1` for the `x < 2` base case, and the iterative / matrix / iterator variants seeded with `(1, 1)` (or computed `F(x+1)`). The result for every input was off by one position in the sequence:

| input | before | after (this PR) |
|------:|-------:|-------:|
|     0 |      1 |      0 |
|     1 |      1 |      1 |
|     7 |     21 |     13 |
|    32 | 3524578 | 2178309 |

Fifteen C++ files, five Java files, four C# files, three Go files, two Rust files, eight Haskell files, and two Pascal files all encoded the same off-by-one. Lisp / Ada / Eiffel are commented out of the `Makefile` build today but are fixed for consistency too.

## Approach

* Recursive base case: `return x` (or `num` / `*value` / `this.value` / `f.n` …) when `x < 2` instead of `return 1`.
* `java/LowLatency.java`: short-circuit `x < 2` and drop the `+1` index shift on `n`.
* `cpp/loop.cpp`, `cpp/matrixes.cpp`, `cpp/binpow-matrix.cpp`, `cpp/interpreter.cpp`, `go/loop.go`, `haskell/iterate.hs`, `haskell/object_dynamic.hs`, `haskell/tail_recursion.hs`, `haskell/zipwith.hs`: seed `(0, 1)` instead of `(1, 1)` and drop the `+1` shifts.
* `cpp/decorators.cpp`: `First.get()` returns 0 (`Second` keeps `1`) so the iterator yields the standard sequence from index 0.

The Makefile’s cross-implementation consistency check (`uniq | wc -l == 1` over the first stdout line of every binary) still passes — every implementation now agrees on `32-th Fibonacci number is 2178309` (was `3524578`). The `local` CI job ran the full `make -e FAST=1 INPUT=7` and produced consistent output across C++, Rust, Java, Go, Haskell, Pascal and C#.

## Test reproduction

Adds `java/FiboTest` (a plain `main` class, no JUnit) that exercises `fibo(0)..fibo(12)` on the five Java implementations against the canonical sequence. A new `make test` target compiles and runs it.

* On master: `make test` reports 60 failures (12 inputs × 5 implementations, all off by one).
* On this branch: `FiboTest: all checks passed`.

`FiboTest.java` is excluded from `JAVAS` so it is not picked up as a native-image build target.

## CI

`local`, `sa`, `pdd`, `xcop`, `actionlint`, `checkmake`, `copyrights`, `markdown-lint`, `reuse`, `shellcheck`, `typos`, `yamllint` all pass. `start-instance` / `terminate-instance` (the EC2-backed `quick` workflow) fail because fork PRs cannot read the AWS secrets — the same pattern as the recently merged #77.

## Test plan
- [x] `make test` (Java unit test) passes
- [x] `local` CI: `make -e FAST=1 INPUT=7` passes (cross-language consistency check)
- [x] All 15 C++ binaries + 2 Rust + 3 Go + 5 Java verified locally for `fibo(0)=0`, `fibo(7)=13`, `fibo(32)=2178309`
- [x] `sa`, `xcop`, `pdd`, `actionlint`, `checkmake`, `copyrights`, `markdown-lint`, `reuse`, `shellcheck`, `typos`, `yamllint` pass