### PR TITLE
#13: keep rust recursion call in loop

### DIFF
--- a/rust/recursion.rs
+++ b/rust/recursion.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2022-2026 Yegor Bugayenko
 // SPDX-License-Identifier: MIT
 
-use std::env;
+use std::{env, hint};
 
 pub fn fibonacci(input: u32) -> u32 {
 	match input {
@@ -18,7 +18,7 @@ pub fn main() {
 	let mut total = 0;
 	let mut f = 0;
 	for _ in 0..cycles {
-		f = fibonacci(input);
+		f = fibonacci(hint::black_box(input));
 		total += f;
 	}
   	println!("{}-th Fibonacci number is {}\nTotal is {}\n", input, f, total);


### PR DESCRIPTION
Fixes #13

Summary:
- pass the loop input through `std::hint::black_box` before calling `fibonacci`
- keeps the optimized Rust recursion benchmark from hoisting the invariant call out of the cycle loop

Validation:
- `rustc -C opt-level=3 --emit=asm -o /tmp/fibonacci-recursion-before.s rust/recursion.rs` before the patch showed one main-path `fibonacci` call followed by `imull` outside the cycle loop
- `rustc -C opt-level=3 --emit=asm -o /tmp/fibonacci-recursion-after-min.s rust/recursion.rs` after the patch shows the `fibonacci` call inside loop label `LBB10_129`
- `rustc -C opt-level=3 -o /tmp/fibonacci-recursion rust/recursion.rs && /tmp/fibonacci-recursion 7 3` -> `7-th Fibonacci number is 13`, `Total is 39`
- `git diff --check HEAD~1..HEAD`
- `git diff HEAD~1..HEAD | gitleaks stdin --no-banner --redact --exit-code 1`

Local limitation:
- Full `make -e FAST=1 INPUT=7` is blocked on this macOS host by GNU Make 3.81 handling of `.ONESHELL`; it stops at `while true; do` in the `reports/%.txt` recipe.
